### PR TITLE
A basic Stub Stencil

### DIFF
--- a/Templates/Stub/README.md
+++ b/Templates/Stub/README.md
@@ -1,0 +1,50 @@
+# AutoStubbable
+
+Allows the ability to automatically create stubs for tests and mock network returns.
+
+## Notes
+This template uses Fakery as a dependency to create fake data.
+
+## Options
+
+### StubValue
+ - Allows you to change what the stub value is
+
+### NoMock
+- Skips a property to mock
+
+
+## Example
+
+```
+// sourcery: AutoStubbable
+public struct KeychainUser {
+
+    public let userName: String
+    public let userID: Int
+
+    // sourcery: StubValue=UserType.executive
+    public userType: Int
+
+    public let store: SecureLoginStore
+    public let user: User
+}
+```
+
+```
+public extension KeychainUser {
+  static func stub (
+    userName: String = .random,
+    userID: Int = Faker.shared.number.randomInt(),
+    userType: Int = UserType.executive,
+    user: User = User.stub()
+   ) -> KeychainUser {
+      return KeychainUser(
+         userName: userName,
+         userID: userID,
+         userType: userType,
+         user: user
+      )
+   }
+}
+```

--- a/Templates/Stub/stub.stencil
+++ b/Templates/Stub/stub.stencil
@@ -1,0 +1,50 @@
+{% for argument in argument.imports %}
+import {{ argument }}
+{% endfor %}
+import Fakery
+
+{% macro stubValue variable %}{#
+#}{% if variable.annotations.StubValue %}{{ variable.annotations.StubValue }}{% else %}{#
+#}{% if variable.type.annotations.AutoStubbable %}{{ variable.unwrappedTypeName }}.stub(){% else %}{#
+#}{% if variable.isArray %}[]{% else %}{#
+#}{% if variable.unwrappedTypeName == "Int" %}Faker.shared.number.randomInt(){% else %}{#
+#}{% if variable.unwrappedTypeName == "String" %}.random{% else %}{#
+#}{% if variable.unwrappedTypeName == "Double" %}Faker.shared.number.randomDouble(){% else %}{#
+#}{% if variable.unwrappedTypeName == "Bool" %}Faker.shared.number.randomBool(){% else %}{#
+#}{% if variable.unwrappedTypeName == "Date" %}Date(){% else %}{#
+#}{% if variable.unwrappedTypeName == "Decimal" %}Decimal(Faker.shared.number.randomDouble()){% else %}{#
+#}{% if variable.unwrappedTypeName == "URL" %}URL(string: "www.google.ca")!{% else %}{#
+#}{% if variable.unwrappedTypeName == "UIImage" %}UIImage(){% else %}{#
+#}{{ variable.unwrappedTypeName }}(){#
+#}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{#
+#}{% endmacro %}
+
+{% macro stub type %}
+{{ type.accessLevel }} extension {{ type.name }} {
+	static func stub (
+		{% for variable in type.allVariables|!annotated:"NoMock" %}
+		{{ variable.name }}: {{ variable.typeName }} = {% call stubValue variable %}{% if not forloop.last %},{% endif %}
+		{% endfor %}
+	) -> {{ type.name }} {
+		{% call stubReturn type %}
+	}
+}
+{% endmacro %}
+
+{% macro stubReturn type %}
+		return {{ type.name }}(
+			{% for variable in type.allVariables|!annotated:"NoMock" %}
+			{{ variable.name }}: {{ variable.name }}{% if not forloop.last %},{% endif %}
+			{% endfor %}
+			)
+{% endmacro %}
+
+// Options: NoMock - skips property to Mock
+
+{% for type in types.structs|annotated:"AutoStubbable" %}
+{% call stub type %}
+{% endfor %}
+
+{% for type in types.classes|annotated:"AutoStubbable" %}
+{% call stub type %}
+{% endfor %}


### PR DESCRIPTION
This particular stub.stencil uses [Fakery](https://github.com/vadymmarkov/Fakery) for stubbing out the data. 

I know Stephen had some issues with this way of doing thing in certain tests, but it works in my scenario. 